### PR TITLE
Add configurable button click duration limit

### DIFF
--- a/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_buttons.yaml
+++ b/ESPHome/TX-Ultimate-Easy-ESPHome_core_hw_buttons.yaml
@@ -25,7 +25,7 @@ substitutions:
   BUTTON_4_ACTION_FAILSAFE_TEXT: "Relay 4 (API failsafe only)"
 
   BUTTON_CLICK_MIN_LENGTH: '50'    # The minimum duration the click should last, in msec
-  BUTTON_CLICK_MAX_LENGTH: '350'   # The maximum duration the click should last, in msec
+  BUTTON_CLICK_MAX_LENGTH: '350'   # Default maximum duration a click should last, in msec
   BUTTON_MULTI_CLICK_DELAY: '250'  # The time to wait for another click, in msec
   BUTTON_PRESS_TIMEOUT: '10000'    # Ignore if button is pressed for longer than this time, in msec
   BUTTON_LONG_PRESS_DELAY: '800'   # The time to wait to consider a long press, in msec
@@ -92,6 +92,21 @@ globals:
     type: uint8_t
     restore_value: false
     initial_value: '0'
+
+number:
+  - id: nr_button_click_max_duration
+    name: Button click duration limit
+    icon: mdi:timer-cog-outline
+    unit_of_measurement: ms
+    platform: template
+    min_value: ${BUTTON_CLICK_MIN_LENGTH}
+    max_value: 2000
+    step: 10
+    initial_value: ${BUTTON_CLICK_MAX_LENGTH}
+    optimistic: true
+    restore_value: true
+    entity_category: config
+    internal: false
 
 script:
   - id: !extend boot_initialize
@@ -235,6 +250,7 @@ script:
           if (id(gang_count) >= 4)
             ESP_LOGCONFIG("${TAG_CORE_HW_BUTTONS}", "  Relay 4: %s", sl_button_4_action->has_state() ?
                                                                       sl_button_4_action->state.c_str() : "Unknown");
+          ESP_LOGCONFIG("${TAG_CORE_HW_BUTTONS}", "Button click duration limit: %.0fms", id(nr_button_click_max_duration)->state);
 
   - id: !extend dump_config_list_packages
     then:
@@ -314,12 +330,16 @@ script:
           if (id(button_press_start_time) > 0 and
               id(button_press_start_time) < current_time) {
             uint32_t press_duration  = current_time - id(button_press_start_time);
+            uint32_t click_max_duration = static_cast<uint32_t>(id(nr_button_click_max_duration)->state);
+            if (click_max_duration < ${BUTTON_CLICK_MIN_LENGTH}) {
+              click_max_duration = ${BUTTON_CLICK_MIN_LENGTH};
+            }
             // Handle overflow (optional, since it's unlikely to happen here)
             ESP_LOGI("${TAG_CORE_HW_BUTTONS}", "Button press duration: %" PRIu32 " ms", press_duration);
             if (press_duration < ${BUTTON_CLICK_MIN_LENGTH}) {
               ESP_LOGW("${TAG_CORE_HW_BUTTONS}", "Ignoring button press (too short)");
             } else if (press_duration >= ${BUTTON_CLICK_MIN_LENGTH} and
-                        press_duration <= ${BUTTON_CLICK_MAX_LENGTH}) { // Short/normal click
+                        press_duration <= click_max_duration) { // Short/normal click
               button_click_event->execute(id(button_press_button), id(click_counter));
             } else if (press_duration >= ${BUTTON_LONG_PRESS_DELAY} and press_duration <= ${BUTTON_PRESS_TIMEOUT}) {
               button_action->execute(id(button_press_button), "long_press", 1);

--- a/README.md
+++ b/README.md
@@ -352,6 +352,7 @@ If the device isn't discovered automatically:
 3. Optional: Configure advanced features
    - LED behaviors
    - Touch duration
+   - Button click duration limit
    - Haptic feedback
    - Audio feedback
 4. Test your configuration:
@@ -378,6 +379,7 @@ After installation, you can:
 TX Ultimate Easy offers extensive configuration options:
 
 - Touch panel gestures
+- Button click duration limit
 - LED colors, patterns, and behaviors
 - Relay modes and functions
 - Audio and haptic feedback settings


### PR DESCRIPTION
## Summary
- add a Home Assistant number entity to configure the maximum touch duration that still counts as a button click
- honor the configurable limit when processing touch releases and include it in the component diagnostics output
- document the new button click duration option in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4270a278c832f9dd81865d2c77cd4